### PR TITLE
Fix for missing import warnings

### DIFF
--- a/vasprun/__init__.py
+++ b/vasprun/__init__.py
@@ -7,6 +7,7 @@ from pprint import pprint
 from optparse import OptionParser
 import pandas as pd
 from tabulate import tabulate
+import warnings
 
 import matplotlib as mpl
 mpl.use("Agg")


### PR DESCRIPTION
The `warnings` module was previously not imported, leading to an error if a float overflow was detected in `_vasprun_float()`.

This pull request fixes this by adding `import warnings` to `__init__.py`.